### PR TITLE
feat: Be more lenient on errors if app.config.sphinxjs_lax is set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,6 +307,11 @@ Configuration Reference
 ``jsdoc_cache``
   Path to a file where jsdoc output will be cached. If omitted, jsdoc will be run every time Sphinx is. If you have a large number of source files, it may be beneficial to configure this value. But be careful: the cache is not automatically flushed if your source code changes; you must delete it manually.
 
+``sphinx_js_lax``
+  If `True`, doclet conflicts and parsing errors will result in warnings instead of exceptions.
+  Useful when starting to use sphinx-js on an existing project where you do not want to fix
+  all errors upfront.
+
 Example
 =======
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ recommonmark==0.4.0
 # with regard to how it emits class names and em dashes from
 # time to time:
 Sphinx==1.7.2
+mock==3.0.5

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -50,11 +50,11 @@ def gather_doclets(app):
                 d)
         except PathTaken as conflict:
             conflicts.append(conflict.segments)
-        except ParseError:
+        except ParseError as e:
             if not app.config.sphinx_js_lax:
                 raise
             else:
-                logger.warning('Could not parse correctly %s' % d)
+                logger.warning('Could not parse path correctly %s' % e.text)
     if conflicts:
         exception = PathsTaken(conflicts)
         if not app.config.sphinx_js_lax:

--- a/tests/test_doclets.py
+++ b/tests/test_doclets.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 from os.path import abspath
 
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
 import pytest
 from sphinx.errors import SphinxError
 
-from sphinx_js.doclets import doclet_full_path, root_or_fallback
+from sphinx_js.doclets import doclet_full_path, root_or_fallback, gather_doclets, PathsTaken
 
 
 def test_doclet_full_path():
@@ -34,3 +39,87 @@ def test_relative_path_root():
     with pytest.raises(SphinxError):
         root_or_fallback(None, ['a', 'b'])
     assert root_or_fallback('smoo', ['a']) == abspath('smoo')
+
+
+CONFLICTED_DOCLETS = [
+    {
+        'comment': True,
+        'undocumented': False,
+        'longname': 'best#thing~yeah',
+        'meta': {
+            'filename': 'utils.jsm',
+            'path': '/boogie/smoo/Checkouts/fathom'
+        }
+    },
+    {
+        'comment': True,
+        'undocumented': False,
+        'longname': 'best#thing~yeah',
+        'meta': {
+            'filename': 'utils.jsm',
+            'path': '/boogie/smoo/Checkouts/fathom'
+        }
+    },
+    {
+        'comment': True,
+        'undocumented': False,
+        'longname': 'best#thing~woot',
+        'meta': {
+            'filename': 'utils.jsm',
+            'path': '/boogie/smoo/Checkouts/fathom'
+        }
+    },
+    {
+        'comment': True,
+        'undocumented': False,
+        'longname': 'best#thing~woot',
+        'meta': {
+            'filename': 'utils.jsm',
+            'path': '/boogie/smoo/Checkouts/fathom'
+        }
+    }
+]
+
+
+def mock_analyze_jsdoc(doclets):
+    def analyze(source_paths, app):
+        return doclets
+    return analyze
+
+
+@patch(
+    'sphinx_js.doclets.ANALYZERS', {
+        'javascript': mock_analyze_jsdoc(CONFLICTED_DOCLETS)
+    }
+)
+def test_gather_doclets_conflicted_lax():
+    app = Mock()
+    app.config.js_language = 'javascript'
+    app.config.js_source_path = 'source-path'
+    app.config.root_for_relative_js_paths = '/boogie/smoo/Checkouts/fathom'
+
+    with patch('sphinx_js.doclets.logger', Mock()) as m:
+        gather_doclets(app)
+
+        message, = m.warning.call_args_list[0][0]
+        assert './utils.best#thing~yeah' in message
+        assert './utils.best#thing~woot' in message
+
+
+@patch(
+    'sphinx_js.doclets.ANALYZERS', {
+        'javascript': mock_analyze_jsdoc(CONFLICTED_DOCLETS)
+    }
+)
+def test_gather_doclets_conflicted():
+    app = Mock()
+    app.config.js_language = 'javascript'
+    app.config.js_source_path = 'source-path'
+    app.config.root_for_relative_js_paths = '/boogie/smoo/Checkouts/fathom'
+    app.config.sphinx_js_lax = False
+
+    with pytest.raises(PathsTaken) as e:
+        gather_doclets(app)
+    message = str(e.value)
+    assert './utils.best#thing~yeah' in message
+    assert './utils.best#thing~woot' in message


### PR DESCRIPTION
When integrating sphinxjs for a multi repository documentation site, I stumbled
upon several conflicts errors and `Rule 'path_and_formal_params' didn't match at` (#109).

For my usecase, it is more convenient to ignore those errors and fix them
on a case by case basis, so I do not mind if I ignore those doclets.

This PR adds a config attribute `sphinxjs_lax` that make sphinxjs doclet generation
not fail if it has errors.