### PR TITLE
fix: mismatch between tsconfig.json and typedoc.json (Close #80)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,10 @@ Configuration Reference
   A list of directories to scan (non-recursively) for JS or TS source files, relative to Sphinx's conf.py file. Can be a string instead if there is only one. If there is more than one, ``root_for_relative_js_paths`` must be specified as well. Defaults to '../'.
 
 ``jsdoc_config_path``
-  A conf.py-relative path to a JSDoc config file, which is useful if you want to specify your own JSDoc options, like recursion and custom filename matching. If using TypeDoc, you can also point to a ``tsconfig.json`` file.
+  A conf.py-relative path to a JSDoc config file, which is useful if you want to specify your own JSDoc options, like recursion and custom filename matching. If using TypeDoc, you can also point to a ``typedoc.json`` file.
+
+``jsdoc_tsconfig_path``
+  If using TypeDoc, specify the path of ``tsconfig.json`` file
 
 ``root_for_relative_js_paths``
   Relative JS entity paths are resolved relative to this path. Defaults to ``js_source_path`` if it is only one item.

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -36,7 +36,8 @@ class Analyzer:
     def from_disk(cls, abs_source_paths, app, base_dir):
         json = typedoc_output(abs_source_paths,
                               app.confdir,
-                              app.config.jsdoc_config_path)
+                              getattr(app.config, 'jsdoc_config_path', None),
+                              getattr(app.config, 'jsdoc_tsconfig_path', None))
         return cls(json, base_dir)
 
     def get_object(self, path_suffix, as_type=None):
@@ -311,12 +312,15 @@ class Analyzer:
             description=signature.get('comment', {}).get('returns', '').strip())]
 
 
-def typedoc_output(abs_source_paths, sphinx_conf_dir, config_path):
+def typedoc_output(abs_source_paths, sphinx_conf_dir, config_path, tsconfig_path=None):
     """Return the loaded JSON output of the TypeDoc command run over the given
     paths."""
     command = Command('typedoc')
     if config_path:
-        command.add('--tsconfig', normpath(join(sphinx_conf_dir, config_path)))
+        command.add('--options', normpath(join(sphinx_conf_dir, config_path)))
+
+    if tsconfig_path:
+        command.add('--tsconfig', normpath(join(sphinx_conf_dir, tsconfig_path)))
 
     with NamedTemporaryFile(mode='w+b') as temp:
         command.add('--json', temp.name, *abs_source_paths)

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -8,5 +8,6 @@ master_doc = 'index'
 author = u'Erik Rose'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-jsdoc_config_path = '../tsconfig.json'
+jsdoc_config_path = '../typedoc.json'
+jsdoc_tsconfig_path = '../tsconfig.json'
 js_language = 'typescript'

--- a/tests/test_build_ts/source/typedoc.json
+++ b/tests/test_build_ts/source/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "module": "modules"
+}

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -35,7 +35,7 @@ class SphinxBuildTestCase(ThisDirTestCase):
         cls.docs_dir = join(cls.this_dir(), 'source', 'docs')
         # -v for better tracebacks:
         if sphinx_main([cls.docs_dir, '-b', cls.builder, '-v', '-E', join(cls.docs_dir, '_build')]):
-                raise RuntimeError('Sphinx build exploded.')
+            raise RuntimeError('Sphinx build exploded.')
 
     @classmethod
     def teardown_class(cls):
@@ -75,6 +75,7 @@ class TypeDocTestCase(ThisDirTestCase):
         cls.json = typedoc_output([join(cls._source_dir, file)
                                    for file in cls.files],
                                   cls._source_dir,
+                                  None,
                                   'tsconfig.json')
         index_by_id({}, cls.json)
 


### PR DESCRIPTION
The parameter `jsdoc_config_path` was pointing to `typedoc --tsconfig` which is the compiler options, it should be the typedoc configuration `typedoc --options`

I added a parameter `jsdoc_tsconfig_path` to be able to specify the `typedoc --tsconfig` if needed

I updated unit test and doc.

It is a breaking change so we might want to bump version or add migration note. Available to update the PR as needed.