### PR TITLE
Support for JSDocs '@see {@link}' tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -334,8 +334,7 @@ Or, if you prefer, the Fathom repo carries a `Travis CI configuration <https://g
 Caveats
 =======
 
-* We don't understand the inline JSDoc constructs like ``{@link foo}``; you have to use Sphinx-style equivalents for now, like ``:js:func:`foo``` (or simply ``:func:`foo``` if you have set ``primary_domain = 'js'`` in conf.py.
-* So far, we understand and convert the JSDoc block tags ``@param``, ``@returns``, ``@throws``, ``@example`` (without the optional ``<caption>``), ``@deprecated``, ``@see``, and their synonyms. Other ones will go *poof* into the ether.
+* So far, we understand and convert the JSDoc block tags ``@param``, ``@returns``, ``@throws``, ``@example`` (without the optional ``<caption>``), ``@deprecated``, ``@see``, @see {@link} and their synonyms. Other ones will go *poof* into the ether.
 
 Tests
 =====

--- a/README.rst
+++ b/README.rst
@@ -334,7 +334,7 @@ Or, if you prefer, the Fathom repo carries a `Travis CI configuration <https://g
 Caveats
 =======
 
-* So far, we understand and convert the JSDoc block tags ``@param``, ``@returns``, ``@throws``, ``@example`` (without the optional ``<caption>``), ``@deprecated``, ``@see``, @see {@link} and their synonyms. Other ones will go *poof* into the ether.
+* So far, we understand and convert the JSDoc block tags ``@param``, ``@returns``, ``@throws``, ``@example`` (without the optional ``<caption>``), ``@deprecated``, ``@see``, ``@see {@link}`` and their synonyms. Other ones will go *poof* into the ether.
 
 Tests
 =====

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -164,6 +164,19 @@ class JsRenderer(object):
                     # restructuredtext.html#field-lists.
                     yield [rst.escape(h) for h in heads], unwrapped(tail)
 
+    def _prepare_see_alsos(self, see_alsos):
+        map_see_alsos = {"internal": [], "external": []}
+        for ref in see_alsos:
+            # prepare links like {@link http://...}
+            # split on @link tag, slice to drop the curly brackets,
+            # strip to remove whitespaces
+            if "@link" in ref:
+                reference = ''.join(ref.split("@link"))[1:-1].strip()
+                map_see_alsos["external"].append(reference)
+            else:
+                map_see_alsos["internal"].append(ref)
+        return map_see_alsos
+
 
 class AutoFunctionRenderer(JsRenderer):
     _template = 'function.rst'
@@ -178,7 +191,7 @@ class AutoFunctionRenderer(JsRenderer):
             examples=obj.examples,
             deprecated=obj.deprecated,
             is_optional=obj.is_optional,
-            see_also=obj.see_alsos,
+            see_also=self._prepare_see_alsos(obj.see_alsos),
             content='\n'.join(self._content))
 
 
@@ -220,7 +233,7 @@ class AutoClassRenderer(JsRenderer):
             fields=self._fields(constructor),
             examples=constructor.examples,
             deprecated=constructor.deprecated,
-            see_also=constructor.see_alsos,
+            see_also=self._prepare_see_alsos(constructor.see_alsos),
             exported_from=obj.exported_from,
             class_comment=obj.description,
             is_abstract=isinstance(obj, Class) and obj.is_abstract,
@@ -311,7 +324,7 @@ class AutoAttributeRenderer(JsRenderer):
             description=obj.description,
             deprecated=obj.deprecated,
             is_optional=obj.is_optional,
-            see_also=obj.see_alsos,
+            see_also=self._prepare_see_alsos(obj.see_alsos),
             examples=obj.examples,
             type=obj.type,
             content='\n'.join(self._content))

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -165,19 +165,24 @@ class JsRenderer(object):
                     yield [rst.escape(h) for h in heads], unwrapped(tail)
 
     def _prepare_see_alsos(self, see_alsos):
-        map_see_alsos = {"internal": [], "external": []}
+        map_see_alsos = {'internal': [], 'external': []}
         for ref in see_alsos:
             # skip empty @see
             if ref is None:
                 continue
             # prepare links like {@link http://...}
-            # split on @link tag, slice to drop the curly brackets,
+            # split on tag, slice to drop the curly brackets,
             # strip to remove whitespaces
-            if "@link" in ref:
-                reference = ''.join(ref.split("@link"))[1:-1].strip()
-                map_see_alsos["external"].append(reference)
+            link_synonmys = ['@linkplain', '@linkcode', '@link']
+            if link_synonmys[-1] in ref:
+                for synonym in link_synonmys:
+                    if synonym not in ref:
+                        continue
+                    reference = ''.join(ref.split(synonym))[1:-1].strip()
+                    map_see_alsos['external'].append(reference)
+                    break
             else:
-                map_see_alsos["internal"].append(ref)
+                map_see_alsos['internal'].append(ref)
         return map_see_alsos
 
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -167,6 +167,9 @@ class JsRenderer(object):
     def _prepare_see_alsos(self, see_alsos):
         map_see_alsos = {"internal": [], "external": []}
         for ref in see_alsos:
+            # skip empty @see
+            if ref is None:
+                continue
             # prepare links like {@link http://...}
             # split on @link tag, slice to drop the curly brackets,
             # strip to remove whitespaces

--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -20,11 +20,14 @@
 {% endmacro %}
 
 {% macro see_also(items) %}
-{% if items -%}
+{% if items.internal or items.external -%}
 .. seealso::
 
-   {% for reference in items -%}
+   {% for reference in items.internal -%}
    - :any:`{{ reference }}`
+   {% endfor %}
+   {% for reference in items.external -%}
+   - {{ reference }}
    {% endfor %}
 {%- endif %}
 {% endmacro %}

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Return the ratio of the inline text length of the links in an element to
  * the inline text length of the entire element.
@@ -215,6 +216,21 @@ const SeeAttribute = null;
  * @see DeprecatedAttribute
  */
 class SeeClass {}
+
+/**
+ * @see {@link https://github.com/mozilla/sphinx-js}
+ */
+function seeLinkFunction() {}
+
+/**
+ * @see {@link https://github.com/mozilla/sphinx-js}
+ */
+const SeeLinkAttribute = null;
+
+/**
+ * @see {@link https://github.com/mozilla/sphinx-js}
+ */
+class SeeLinkClass {}
 
 /**
  * @arg fnodeA {Node|Fnode}

--- a/tests/test_build_js/source/docs/autoattribute_see_link.rst
+++ b/tests/test_build_js/source/docs/autoattribute_see_link.rst
@@ -1,0 +1,1 @@
+.. js:autoattribute:: SeeLinkAttribute

--- a/tests/test_build_js/source/docs/autoclass_see_link.rst
+++ b/tests/test_build_js/source/docs/autoclass_see_link.rst
@@ -1,0 +1,1 @@
+.. js:autoclass:: SeeLinkClass

--- a/tests/test_build_js/source/docs/autofunction_see_link.rst
+++ b/tests/test_build_js/source/docs/autofunction_see_link.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: seeLinkFunction

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -119,6 +119,14 @@ class Tests(SphinxBuildTestCase):
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
 
+    def test_autofunction_see_link(self):
+        """Make sure @see {@link} tags work with autofunction."""
+        self._file_contents_eq(
+            'autofunction_see_link',
+            'seeLinkFunction()\n\n'
+            '   See also:\n\n'
+            '     * https://github.com/mozilla/sphinx-js\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""
@@ -257,6 +265,14 @@ class Tests(SphinxBuildTestCase):
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
 
+    def test_autoclass_see_link(self):
+        """Make sure @see {@link} tags work with autoclass."""
+        self._file_contents_eq(
+            'autoclass_see_link',
+            'class SeeLinkClass()\n\n'
+            '   See also:\n\n'
+            '     * https://github.com/mozilla/sphinx-js\n')
+
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
         self._file_contents_eq(
@@ -293,6 +309,14 @@ class Tests(SphinxBuildTestCase):
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
+
+    def test_autoattribute_see_link(self):
+        """Make sure @see {@link} tags work with autoattribute."""
+        self._file_contents_eq(
+            'autoattribute_see_link',
+            'SeeLinkAttribute\n\n'
+            '   See also:\n\n'
+            '     * https://github.com/mozilla/sphinx-js\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""


### PR DESCRIPTION
With the ``@see`` tag it is only possible to reference internal documented objects like functions, classes, etc.
Sphinx raises a warning if the referenced target could not be found and it just displays the non-clickable link.

```js
/**
 * @see https://github.com/mozilla/sphinx-js
 */
bad_link_function() {}
```
![image](https://user-images.githubusercontent.com/34922647/116979593-7c5df800-acc5-11eb-833d-9dbc8b3f4d6a.png)

![image](https://user-images.githubusercontent.com/34922647/116981174-72d58f80-acc7-11eb-90df-857d9531ad6b.png)

To reference external resources we use the ``@see {@link}`` tag a lot from within our JavaScript code. So this pull request
adds the functionality to support JSDocs ```@see {@link}``` syntax.
Here's an example:

```js
/**
 * @see {@link https://github.com/mozilla/sphinx-js}
 *
 * @returns {void}
 */
see_link_function() {}
```
![image](https://user-images.githubusercontent.com/34922647/116983181-14f67700-acca-11eb-8c28-8074dd268c28.png)

The pull request covers the synonyms ```@linkcode``` and ```@linkplain``` though switching to a monospace font is not supported. JSDoc also provides different formats for the ```@link``` tag (see https://jsdoc.app/tags-inline-link.html). For now, I just covered the format ```@see {@link URL}```.

Notable changes are
* change docs
* implement function _prepare_see_alsos() in JSRenderer base class
* call _prepare_see_alsos() in each renderer class
* change common template
* write some test cases