### PR TITLE
add js autodoc default options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -314,6 +314,12 @@ Configuration Reference
 ``jsdoc_cache``
   Path to a file where JSDoc output will be cached. If omitted, JSDoc will be run every time Sphinx is. If you have a large number of source files, it may help to configure this value. But be careful: the cache is not automatically flushed if your source code changes; you must delete it manually.
 
+``js_autodoc_default_options``
+  A dictionary containing default autodoc options. Options are ``members`` and ``private-members``. Both are set to ``False`` by default. If the ``members`` is set to ``True``, the option tells each autoclass directive to include all members
+  without explicitly specifying it on every autoclass directive. This can also be a string of comma-seperated names which should be included on every autoclass directive by default. If omitted or set to ``False``, this options is ignored.
+  Set ``private-members`` to ``True``, if you'd like to display private members by default.
+
+
 Example
 =======
 

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -31,6 +31,7 @@ def setup(app):
     app.add_config_value('js_language', 'javascript', 'env')
     app.add_config_value('js_source_path', '../', 'env')
     app.add_config_value('jsdoc_config_path', None, 'env')
+    app.add_config_value('js_autodoc_default_options', {}, 'env')
 
     # We could use a callable as the "default" param here, but then we would
     # have had to duplicate or build framework around the logic that promotes

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -52,7 +52,7 @@ def auto_class_directive_bound_to_app(app):
         option_spec = JsDirective.option_spec.copy()
         option_spec.update({
             'members': lambda members: ([m.strip() for m in members.split(',')]
-                                        if members else []),
+                                        if members else None),
             'exclude-members': _members_to_exclude,
             'private-members': flag})
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -164,6 +164,26 @@ class JsRenderer(object):
                     # restructuredtext.html#field-lists.
                     yield [rst.escape(h) for h in heads], unwrapped(tail)
 
+    def _default_options(self):
+        options = ['members', 'private-members']
+        extendable_options = ['members']
+        options_active = self._options
+        config_default_options = self._app.config['js_autodoc_default_options']
+        for name in options:
+            if name in config_default_options:
+                if name in options_active:
+                    # take value from options if present and not None and extend it
+                    # with js_autodoc_default_options if necessary
+                    if isinstance(config_default_options[name], str) and isinstance(options_active[name], list):
+                        if name in extendable_options:
+                            options_active[name] += [val.strip() for val in config_default_options[name].split(',')]
+                else:
+                    # typ check default option
+                    # set to default if option is True or None else ignore option
+                    val = config_default_options[name]
+                    if val in [True, None, '1']:
+                        options_active[name] = None
+
 
 class AutoFunctionRenderer(JsRenderer):
     _template = 'function.rst'
@@ -185,6 +205,10 @@ class AutoFunctionRenderer(JsRenderer):
 class AutoClassRenderer(JsRenderer):
     _template = 'class.rst'
     _renderer_type = 'class'
+
+    def __init__(self, directive, app, arguments=None, content=None, options=None):
+        super().__init__(directive, app, arguments=arguments, content=content, options=options)
+        self._default_options()
 
     def _template_vars(self, name, obj):
         # TODO: At the moment, we pull most fields (params, returns,

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Return the ratio of the inline text length of the links in an element to
  * the inline text length of the entire element.

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Return the ratio of the inline text length of the links in an element to
  * the inline text length of the entire element.

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -1,4 +1,6 @@
-from tests.testing import SphinxBuildTestCase
+from tests.testing import (SphinxBuildTestCase,
+                            SphinxBuildDefaultsAllTestCase,
+                            SphinxBuildDefaultsMembersTestCase)
 
 
 class Tests(SphinxBuildTestCase):
@@ -360,6 +362,74 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '      * **b** -- Next param, which should be part of the same field\n'
             '        list\n')
+
+
+class TestAllDefaultValues(SphinxBuildDefaultsAllTestCase):
+    """Test some feature with default options specified.
+    """
+
+    def test_autoclass_members_list(self):
+        """Make sure a class lists all of its members if default options ``members``
+        equals to true including the private member ``secret()`` and excluding
+        ``anotherMethod``."""
+        self._file_contents_eq(
+            'autoclass',
+            'class ContainingClass(ho)\n'
+            '\n'
+            '   Class doc.\n'
+            '\n'
+            '   Constructor doc.\n'
+            '\n'
+            '   Arguments:\n'
+            '      * **ho** -- A thing\n'
+            '\n'
+            '   ContainingClass.bar\n'
+            '\n'
+            '      Setting this also frobs the frobnicator.\n'
+            '\n'
+            '   ContainingClass.someVar\n'
+            '\n'
+            '      A var\n'
+            '\n'
+            '   ContainingClass.anotherMethod()\n'
+            '\n'
+            '      Another.\n'
+            '\n'
+            '   ContainingClass.secret()\n'
+            '\n'
+            '      Private thing.\n'
+            '\n'
+            '   ContainingClass.someMethod(hi)\n'
+            '\n'
+            '      Here.\n'
+            '\n'
+            '   ContainingClass.yetAnotherMethod()\n'
+            '\n'
+            '      More.\n')
+
+class TestMembersDefaultValue(SphinxBuildDefaultsMembersTestCase):
+    """Test some feature with default options specified.
+    """
+
+    def test_autoclass_some_members_list(self):
+        """Make sure class ClosedClass lists all of its members."""
+        self._file_contents_eq(
+            'autoclass_members_list',
+            'class ClosedClass()\n'
+            '\n'
+            '   Closed class.\n'
+            '\n'
+            '   ClosedClass.publical3()\n'
+            '\n'
+            '      Public thing 3.\n'
+            '\n'
+            '   ClosedClass.publical()\n'
+            '\n'
+            '      Public thing.\n'
+            '\n'
+            '   ClosedClass.publical2()\n'
+            '\n'
+            '      Public thing 2.\n')
 
 
 DESCRIPTION = """

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -51,6 +51,47 @@ class SphinxBuildTestCase(ThisDirTestCase):
         assert self._file_contents(filename) == contents
 
 
+class SphinxBuildDefaultsAllTestCase(SphinxBuildTestCase):
+    """Base class for tests which require a Sphinx tree to be build and then
+    deleted afterwards. The Difference between this and its base class is
+    that we pass some configuration values to conf.py.
+    """
+    @classmethod
+    def setup_class(cls):
+        """Run Sphinx against the dir adjacent to the testcase."""
+        cls.docs_dir = join(cls.this_dir(), 'source', 'docs')
+        # -v for better tracebacks:
+        if sphinx_main([cls.docs_dir,
+                        '-b',
+                        cls.builder,
+                        '-v',
+                        '-E',
+                        '-Djs_autodoc_default_options.members=1',
+                        '-Djs_autodoc_default_options.private-members=1',
+                        join(cls.docs_dir, '_build')]):
+            raise RuntimeError('Sphinx build exploded.')
+
+
+class SphinxBuildDefaultsMembersTestCase(SphinxBuildTestCase):
+    """Base class for tests which require a Sphinx tree to be build and then
+    deleted afterwards. The Difference between this and its base class is
+    that we pass some configuration values to conf.py.
+    """
+    @classmethod
+    def setup_class(cls):
+        """Run Sphinx against the dir adjacent to the testcase."""
+        cls.docs_dir = join(cls.this_dir(), 'source', 'docs')
+        # -v for better tracebacks:
+        if sphinx_main([cls.docs_dir,
+                        '-b',
+                        cls.builder,
+                        '-v',
+                        '-E',
+                        '-Djs_autodoc_default_options.members=publical2',
+                        join(cls.docs_dir, '_build')]):
+            raise RuntimeError('Sphinx build exploded.')
+
+
 class JsDocTestCase(ThisDirTestCase):
     """Base class for tests which analyze a file using JSDoc"""
 


### PR DESCRIPTION
This allows us to omit the options ``:members:`` and ``private-members`` on every single autoclass directive.

conf.py
```python
js_autodoc_default_options = {
    "members": True,            # by default False
    "private-members": True,    # by default False
}
```

JavaScript source
```js
/**
 * TestClass
 */
class TestClass {
    /**
     * A.
     */
    a() {}

    /**
     * B.
     */
    b() {}

    /**
     * C.
     * @private
     */
    c() {}
}
```

.rst file
```code
.. js:autoclass:: TestClass
```

html result

![image](https://user-images.githubusercontent.com/34922647/117032649-f14f2300-ad01-11eb-8738-696e8b5eb09d.png)

Notable changes:
* add config value js_autodoc_default_options (default empty dict)
* implement _default_options() in JSRenderer class
* try to set defaults on initialization of renderer classes (currently only at AutoClassRenderer)
* write some test cases