### PR TITLE
Add support for JSDocs @namespace tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ Finally, if you want full control, pull your namespace members in one at a time 
 
 To reference a namespace from anywhere in your documentation, you can use the ``js:ns`` role
 
-    :js:ns:`SomeNamespace`
+    ``:js:ns:`SomeNamespace```
 
 autoattribute
 -------------

--- a/README.rst
+++ b/README.rst
@@ -248,6 +248,16 @@ When explicitly listing members, you can include ``*`` to include all unmentione
     .. js:autonamespace:: SomeNamespace
        :members: importMethod, *, uncommonlyUsedMethod
 
+Finally, if you want full control, pull your namespace members in one at a time by embedding ``js:autofunction`` or ``js:autoattribute``::
+
+    .. js:autonamespace:: SomeNamespace
+
+       .. js:autofunction:: SomeNamespace.someMethod
+
+       Additional content can go here and appears below the in-code comments,
+       allowing you to intersperse long prose passages and examples that you
+       don't want in your code.
+
 autoattribute
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,38 @@ Finally, if you want full control, pull your class members in one at a time by e
        allowing you to intersperse long prose passages and examples that you
        don't want in your code.
 
+autonamespace
+-------------
+
+Similar to ``js::autoclass`` we provide a ``js:autonamespace`` directive which documents a namespace with its namespace comment. It shares all the features of ``js:autofunction`` and even takes the same ``:short-name:`` flag. The easiest way to use it is to invoke its ``:members:`` option, which automatically documents all its public methods and attributes::
+
+    .. js:autonamespace:: SomeNamespace
+       :members:
+
+You can add private members by saying... ::
+
+    .. js:autonamespace:: SomeNamespace
+       :members:
+       :private-members:
+
+Privacy is determined by JSDoc ``@private`` tag.
+
+Exclude certain members by name with ``:exclude-members:``::
+
+    .. js:autonamespace:: SomeNamespace
+       :members:
+       :exclude-members: Foo, bar, baz
+
+Or explicitly list the members you want. We will respect your ordering. ::
+
+    .. js:autonamespace:: SomeNamespace
+       :members: Qux, qum
+
+When explicitly listing members, you can include ``*`` to include all unmentioned members. This is useful to have control over ordering of some elements, without having to include an exhaustive list. ::
+
+    .. js:autonamespace:: SomeNamespace
+       :members: importMethod, *, uncommonlyUsedMethod
+
 autoattribute
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,10 @@ Finally, if you want full control, pull your namespace members in one at a time 
        allowing you to intersperse long prose passages and examples that you
        don't want in your code.
 
+To reference a namespace from anywhere in your documentation, you can use the ``js:ns`` role
+
+    :js:ns:`SomeNamespace`
+
 autoattribute
 -------------
 

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -9,7 +9,7 @@ from .directives import (auto_class_directive_bound_to_app,
                          auto_namespace_directive_bound_to_app,
                          auto_function_directive_bound_to_app,
                          auto_attribute_directive_bound_to_app,
-                         JSCustomConstructor)
+                         JSNamespace)
 from .jsdoc import Analyzer as JsAnalyzer
 from .typedoc import Analyzer as TsAnalyzer
 
@@ -33,7 +33,7 @@ def setup(app):
                                 auto_namespace_directive_bound_to_app(app))
     app.add_directive_to_domain('js',
                                 'namespace',
-                                JSCustomConstructor)
+                                JSNamespace)
     app.add_role_to_domain('js', 'ns', JSXRefRole(fix_parens=True))
 
     # NOTE: I couldn't find a recommended/denoted way to add a new object type

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -40,7 +40,7 @@ def setup(app):
     # to a specific domain. When using the app.add_object_type() method it is not
     # possible to reference namespace objects 'cause sphinx adds the object to
     # the 'std' domain a not the 'js' domain.
-    JavaScriptDomain.object_types.setdefault('namespace', ObjType(_('namespace'),  'ns'))
+    JavaScriptDomain.object_types.setdefault('namespace', ObjType(_('namespace'), 'ns'))
 
     app.add_directive_to_domain('js',
                                 'autoattribute',

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -1,10 +1,15 @@
 from os.path import join, normpath
 
+from sphinx.domains.javascript import JSXRefRole, JavaScriptDomain
+from sphinx.domains import ObjType
 from sphinx.errors import SphinxError
+from sphinx.locale import _
 
 from .directives import (auto_class_directive_bound_to_app,
+                         auto_namespace_directive_bound_to_app,
                          auto_function_directive_bound_to_app,
-                         auto_attribute_directive_bound_to_app)
+                         auto_attribute_directive_bound_to_app,
+                         JSCustomConstructor)
 from .jsdoc import Analyzer as JsAnalyzer
 from .typedoc import Analyzer as TsAnalyzer
 
@@ -23,6 +28,20 @@ def setup(app):
     app.add_directive_to_domain('js',
                                 'autoclass',
                                 auto_class_directive_bound_to_app(app))
+    app.add_directive_to_domain('js',
+                                'autonamespace',
+                                auto_namespace_directive_bound_to_app(app))
+    app.add_directive_to_domain('js',
+                                'namespace',
+                                JSCustomConstructor)
+    app.add_role_to_domain('js', 'ns', JSXRefRole(fix_parens=True))
+
+    # NOTE: I couldn't find a recommended/denoted way to add a new object type
+    # to a specific domain. When using the app.add_object_type() method it is not
+    # possible to reference namespace objects 'cause sphinx adds the object to
+    # the 'std' domain a not the 'js' domain.
+    JavaScriptDomain.object_types.setdefault('namespace', ObjType(_('namespace'),  'ns'))
+
     app.add_directive_to_domain('js',
                                 'autoattribute',
                                 auto_attribute_directive_bound_to_app(app))

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -111,7 +111,7 @@ def _members_to_exclude(arg):
     return set(a.strip() for a in (arg or '').split(','))
 
 
-class JSCustomConstructor(JSCallable):
+class JSNamespace(JSCallable):
     """Like a callable but with a different prefix."""
     display_prefix = 'namespace '
     allow_nesting = True

--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -229,3 +229,11 @@ class Class(TopLevel, _MembersAndSupers):
     # itself. These are supported and extracted by jsdoc, but they end up in an
     # `undocumented: True` doclet and so are presently filtered out. But we do
     # have the space to include them someday.
+
+
+@dataclass
+class Namespace(TopLevel):
+    #: Namespace members, concretized ahead of time for simplicity. (Otherwise,
+    #: we'd have to pass the doclets_by_namespace map in and keep it around, along
+    #: with a callable that would create the member IRs from it on demand.)
+    members: List[Union[Function, Attribute]]

--- a/sphinx_js/templates/namespace.rst
+++ b/sphinx_js/templates/namespace.rst
@@ -1,6 +1,6 @@
 {% import 'common.rst' as common %}
 
-.. js:namespace:: {{ name }}{{ params }}
+.. js:namespace:: {{ name }}
 
    {{ common.deprecated(deprecated)|indent(3) }}
 

--- a/sphinx_js/templates/namespace.rst
+++ b/sphinx_js/templates/namespace.rst
@@ -1,0 +1,25 @@
+{% import 'common.rst' as common %}
+
+.. js:namespace:: {{ name }}{{ params }}
+
+   {{ common.deprecated(deprecated)|indent(3) }}
+
+   {% if namespace_comment -%}
+     {{ namespace_comment|indent(3) }}
+   {%- endif %}
+
+   {{ common.exported_from(exported_from)|indent(3) }}
+
+   {% for heads, tail in fields -%}
+     :{{ heads|join(' ') }}: {{ tail }}
+   {% endfor %}
+
+   {{ common.examples(examples)|indent(3) }}
+
+   {{ content|indent(3) }}
+
+   {% if members -%}
+     {{ members|indent(3) }}
+   {%- endif %}
+
+   {{ common.see_also(see_also)|indent(3) }}

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Return the ratio of the inline text length of the links in an element to
  * the inline text length of the entire element.

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Return the ratio of the inline text length of the links in an element to
  * the inline text length of the entire element.
@@ -234,3 +235,98 @@ function union(fnodeA) {
  */
 function longDescriptions(a, b) {
 }
+
+/**
+ * Namespace doc.
+ * @namespace
+ */
+ var ContainingNamespace = {
+    /**
+     * A var.
+     */
+    someVar : "containing some text.",
+
+    /**
+     * Another.
+     */
+    anotherMethod : function() {
+    },
+
+    /**
+     * More.
+     */
+    yetAnotherMethod : function() {
+    },
+}
+
+// We won't add any new members to this namespace, because it would break some tests.
+/** Closed namespace. */
+var ClosedNamespace = {
+    /**
+     * Public thing.
+     */
+    publical: function() {},
+
+    /**
+     * Public thing 2.
+     */
+    publical2: function() {},
+
+    /**
+     * Public thing 3.
+     */
+    publical3: function() {},
+}
+
+/**
+ * Non-alphabetical namespace.
+ * @namespace
+ */
+var NonAlphabeticalNamespace = {
+    /** Fun z. */
+    z: function() {},
+
+    /** Fun a. */
+    a: function() {},
+}
+
+/**
+ * This doesn't emit a paramnames key in meta.code.
+ * @namespace
+ */
+const NoParamnamesNamespace = {};
+
+/**
+ * JSDoc example tag for namespace
+ *
+ * @example
+ * // This is the example.
+ * ExampleNamespace.version;
+ *
+ * @namespace
+ */
+var ExampleNamespace = {
+    /**
+     * Namespace version.
+     */
+    version : "1.0"
+}
+
+/**
+ * @deprecated
+ * @namespace
+ */
+var DeprecatedNamespace = {}
+/**
+ * @deprecated don't use anymore
+ * @namespace
+ */
+var DeprecatedExplanatoryNamespace = {}
+
+/**
+ * @see DeprecatedNamespace
+ * @see deprecatedFunction
+ * @see DeprecatedAttribute
+ * @namespace
+ */
+var SeeNamespace = {}

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -235,7 +235,7 @@ function union(fnodeA) {
 function longDescriptions(a, b) {
 }
 
-/*
+/**
  * Class doc.
  */
 class SimpleClass {

--- a/tests/test_build_js/source/docs/autonamespace.rst
+++ b/tests/test_build_js/source/docs/autonamespace.rst
@@ -1,0 +1,1 @@
+.. js:autonamespace:: ContainingNamespace

--- a/tests/test_build_js/source/docs/autonamespace_alphabetical.rst
+++ b/tests/test_build_js/source/docs/autonamespace_alphabetical.rst
@@ -1,0 +1,2 @@
+.. js:autonamespace:: NonAlphabeticalNamespace
+   :members:

--- a/tests/test_build_js/source/docs/autonamespace_deprecated.rst
+++ b/tests/test_build_js/source/docs/autonamespace_deprecated.rst
@@ -1,0 +1,3 @@
+.. js:autonamespace:: DeprecatedNamespace
+
+.. js:autonamespace:: DeprecatedExplanatoryNamespace

--- a/tests/test_build_js/source/docs/autonamespace_example.rst
+++ b/tests/test_build_js/source/docs/autonamespace_example.rst
@@ -1,0 +1,1 @@
+.. js:autonamespace:: ExampleNamespace

--- a/tests/test_build_js/source/docs/autonamespace_exclude_members.rst
+++ b/tests/test_build_js/source/docs/autonamespace_exclude_members.rst
@@ -1,0 +1,3 @@
+.. js:autonamespace:: ClosedNamespace
+   :members:
+   :exclude-members: publical2, publical3

--- a/tests/test_build_js/source/docs/autonamespace_members.rst
+++ b/tests/test_build_js/source/docs/autonamespace_members.rst
@@ -1,0 +1,2 @@
+.. js:autonamespace:: ContainingNamespace
+   :members:

--- a/tests/test_build_js/source/docs/autonamespace_members_list.rst
+++ b/tests/test_build_js/source/docs/autonamespace_members_list.rst
@@ -1,0 +1,2 @@
+.. js:autonamespace:: ClosedNamespace
+   :members: publical3, publical

--- a/tests/test_build_js/source/docs/autonamespace_members_list_star.rst
+++ b/tests/test_build_js/source/docs/autonamespace_members_list_star.rst
@@ -1,0 +1,2 @@
+.. js:autonamespace:: ContainingNamespace
+   :members: someVar, *, yetAnotherMethod

--- a/tests/test_build_js/source/docs/autonamespace_no_paramnames.rst
+++ b/tests/test_build_js/source/docs/autonamespace_no_paramnames.rst
@@ -1,0 +1,3 @@
+Make sure we don't have KeyErrors on naked, memberless objects labeled as namespace:
+
+.. js:autonamespace:: NoParamnamesNamespace

--- a/tests/test_build_js/source/docs/autonamespace_see.rst
+++ b/tests/test_build_js/source/docs/autonamespace_see.rst
@@ -1,0 +1,1 @@
+.. js:autonamespace:: SeeNamespace

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -257,7 +257,6 @@ class Tests(SphinxBuildTestCase):
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
 
-
     def test_autonamespace(self):
         """Make sure namespaces show their namespace comment."""
         contents = self._file_contents('autonamespace')
@@ -349,7 +348,7 @@ class Tests(SphinxBuildTestCase):
             '     Deprecated.\n\n'
             'namespace DeprecatedExplanatoryNamespace()\n\n'
             '   Note:\n\n'
-            '     Deprecated: don\'t use anymore\n')
+            "     Deprecated: don't use anymore\n")
 
     def test_autonamespace_see(self):
         """Make sure @see tags work with autonamespace."""
@@ -367,13 +366,13 @@ class Tests(SphinxBuildTestCase):
         """
         self._file_contents_eq(
             'autonamespace_no_paramnames',
-            'Make sure we don\'t have KeyErrors on naked, memberless objects labeled'
+            "Make sure we don't have KeyErrors on naked, memberless objects labeled"
             '\n'
             'as namespace:\n'
             '\n'
             'namespace NoParamnamesNamespace()\n'
             '\n'
-            '   This doesn\'t emit a paramnames key in meta.code.\n')
+            "   This doesn't emit a paramnames key in meta.code.\n")
 
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -282,18 +282,19 @@ class Tests(SphinxBuildTestCase):
         """
         self._file_contents_eq(
             'autonamespace_members',
-            'namespace ContainingNamespace()\n\n'
+            'namespace ContainingNamespace()\n'
+            '\n'
             '   Namespace doc.\n'
             '\n'
             '   ContainingNamespace.someVar\n'
             '\n'
             '      A var.\n'
             '\n'
-            '   ContainingNamespace.anotherMethod()\n'
+            '   static ContainingNamespace.anotherMethod()\n'
             '\n'
             '      Another.\n'
             '\n'
-            '   ContainingNamespace.yetAnotherMethod()\n'
+            '   static ContainingNamespace.yetAnotherMethod()\n'
             '\n'
             '      More.\n')
 
@@ -302,7 +303,17 @@ class Tests(SphinxBuildTestCase):
         those names and follows the order you specify."""
         self._file_contents_eq(
             'autonamespace_members_list',
-            'namespace ClosedNamespace()\n\n   Closed namespace.\n\n   ClosedNamespace.publical3()\n\n      Public thing 3.\n\n   ClosedNamespace.publical()\n\n      Public thing.\n')
+            'namespace ClosedNamespace()\n'
+            '\n'
+            '   Closed namespace.\n'
+            '\n'
+            '   static ClosedNamespace.publical3()\n'
+            '\n'
+            '      Public thing 3.\n'
+            '\n'
+            '   static ClosedNamespace.publical()\n'
+            '\n'
+            '      Public thing.\n')
 
     def test_autonamespace_members_list_star(self):
         """Make sure including ``*`` in a list of names after
@@ -318,11 +329,11 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '      A var.\n'
             '\n'
-            '   ContainingNamespace.anotherMethod()\n'
+            '   static ContainingNamespace.anotherMethod()\n'
             '\n'
             '      Another.\n'
             '\n'
-            '   ContainingNamespace.yetAnotherMethod()\n'
+            '   static ContainingNamespace.yetAnotherMethod()\n'
             '\n'
             '      More.\n')
 
@@ -330,7 +341,17 @@ class Tests(SphinxBuildTestCase):
         """Make sure members sort alphabetically when not otherwise specified."""
         self._file_contents_eq(
             'autonamespace_alphabetical',
-            'namespace NonAlphabeticalNamespace()\n\n   Non-alphabetical namespace.\n\n   NonAlphabeticalNamespace.a()\n\n      Fun a.\n\n   NonAlphabeticalNamespace.z()\n\n      Fun z.\n')
+            'namespace NonAlphabeticalNamespace()\n'
+            '\n'
+            '   Non-alphabetical namespace.\n'
+            '\n'
+            '   static NonAlphabeticalNamespace.a()\n'
+            '\n'
+            '      Fun a.\n'
+            '\n'
+            '   static NonAlphabeticalNamespace.z()\n'
+            '\n'
+            '      Fun z.\n')
 
     def test_autonamespace_exclude_members(self):
         """Make sure ``exclude-members`` option actually excludes listed

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -257,6 +257,124 @@ class Tests(SphinxBuildTestCase):
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
 
+
+    def test_autonamespace(self):
+        """Make sure namespaces show their namespace comment."""
+        contents = self._file_contents('autonamespace')
+        assert 'Namespace doc.' in contents
+
+    def test_autonamespace_members(self):
+        """Make sure namespaces list their members if ``:members:`` is specified.
+
+        Make sure it shows both functions and attributes and shows getters and
+        setters as if they are attributes. Make sure it doesn't show private
+        members.
+        """
+        self._file_contents_eq(
+            'autonamespace_members',
+            'namespace ContainingNamespace()\n\n'
+            '   Namespace doc.\n'
+            '\n'
+            '   ContainingNamespace.someVar\n'
+            '\n'
+            '      A var.\n'
+            '\n'
+            '   ContainingNamespace.anotherMethod()\n'
+            '\n'
+            '      Another.\n'
+            '\n'
+            '   ContainingNamespace.yetAnotherMethod()\n'
+            '\n'
+            '      More.\n')
+
+    def test_autonamespace_members_list(self):
+        """Make sure including a list of names after ``members`` limits it to
+        those names and follows the order you specify."""
+        self._file_contents_eq(
+            'autonamespace_members_list',
+            'namespace ClosedNamespace()\n\n   Closed namespace.\n\n   ClosedNamespace.publical3()\n\n      Public thing 3.\n\n   ClosedNamespace.publical()\n\n      Public thing.\n')
+
+    def test_autonamespace_members_list_star(self):
+        """Make sure including ``*`` in a list of names after
+        ``members`` includes the rest of the names in the normal order
+        at that point."""
+        self._file_contents_eq(
+            'autonamespace_members_list_star',
+            'namespace ContainingNamespace()\n'
+            '\n'
+            '   Namespace doc.\n'
+            '\n'
+            '   ContainingNamespace.someVar\n'
+            '\n'
+            '      A var.\n'
+            '\n'
+            '   ContainingNamespace.anotherMethod()\n'
+            '\n'
+            '      Another.\n'
+            '\n'
+            '   ContainingNamespace.yetAnotherMethod()\n'
+            '\n'
+            '      More.\n')
+
+    def test_autonamespace_alphabetical(self):
+        """Make sure members sort alphabetically when not otherwise specified."""
+        self._file_contents_eq(
+            'autonamespace_alphabetical',
+            'namespace NonAlphabeticalNamespace()\n\n   Non-alphabetical namespace.\n\n   NonAlphabeticalNamespace.a()\n\n      Fun a.\n\n   NonAlphabeticalNamespace.z()\n\n      Fun z.\n')
+
+    def test_autonamespace_exclude_members(self):
+        """Make sure ``exclude-members`` option actually excludes listed
+        members."""
+        contents = self._file_contents('autonamespace_exclude_members')
+        assert 'publical()' in contents
+        assert 'publical2' not in contents
+        assert 'publical3' not in contents
+
+    def test_autonamespace_example(self):
+        """Make sure @example tags can be documented with autonamespace."""
+        self._file_contents_eq(
+            'autonamespace_example',
+            'namespace ExampleNamespace()\n\n'
+            '   JSDoc example tag for namespace\n\n'
+            '   **Examples:**\n\n'
+            '      // This is the example.\n'
+            '      ExampleNamespace.version;\n')
+
+    def test_autonamespace_deprecated(self):
+        """Make sure @deprecated tags can be documented with autonamespace."""
+        self._file_contents_eq(
+            'autonamespace_deprecated',
+            'namespace DeprecatedNamespace()\n\n'
+            '   Note:\n\n'
+            '     Deprecated.\n\n'
+            'namespace DeprecatedExplanatoryNamespace()\n\n'
+            '   Note:\n\n'
+            '     Deprecated: don\'t use anymore\n')
+
+    def test_autonamespace_see(self):
+        """Make sure @see tags work with autonamespace."""
+        self._file_contents_eq(
+            'autonamespace_see',
+            'namespace SeeNamespace()\n\n'
+            '   See also:\n\n'
+            '     * "DeprecatedNamespace"\n\n'
+            '     * "deprecatedFunction"\n\n'
+            '     * "DeprecatedAttribute"\n')
+
+    def test_autonamespace_no_paramnames(self):
+        """Make sure we don't have KeyErrors on naked, memberless objects
+        labeled as namespace:.
+        """
+        self._file_contents_eq(
+            'autonamespace_no_paramnames',
+            'Make sure we don\'t have KeyErrors on naked, memberless objects labeled'
+            '\n'
+            'as namespace:\n'
+            '\n'
+            'namespace NoParamnamesNamespace()\n'
+            '\n'
+            '   This doesn\'t emit a paramnames key in meta.code.\n')
+
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
         self._file_contents_eq(


### PR DESCRIPTION
Instead of using classes to encapsulate some JS code we often use namespaces.
To document namespaces JSDoc offers the ``@namespace`` tag. 
The documentation looks quite similar to a class documentation.
At first glance, there's just another prefix (namespace instead of class). 

Example JS code

```js
/**
 * A simple namespace.
 * @namespace
 */
var NewNamespace = {
    /** documented as NewNamespace.someAttribute. */
    someAttribute : "foo",

    /**
     * documented as NewNamespace.foo
     * @returns {void}
     */
    foo : function() {},

    /**
     * @returns {void}
     */
    bar : function() {},

    /**
     * @private
     * @returns {void}
     */
    baz : function() {},
};
```

Document namespace like this
```code
.. js:autonamespace:: NewNamespace
    :members:
    :private-members:
    :exclude-members: bar
```
Generated output

![image](https://user-images.githubusercontent.com/34922647/117172992-9df5d700-adcc-11eb-8fb0-4dc81dc43991.png)

Notable changes are:
* add template namespace.rst
  * similar to class.rst
  * no supers, no interface, no is_interface, no is_static
* add directives ``namespace`` and ``autonamespace`` to js domain
  * autonamespace and autoclass have the same options
* add ir class Namespace
* collect doclets by namespace
* add renderer AutoNamespaceRenderer
* write some tests (very similar to autoclass tests)

I'm not sure, if this directive is going to be used by a lot of people. We just wanted to see a slightly different documentation for classes and namespaces. In addition, the changes do no harm on the rest of the code^^