### PR TITLE
automatic module documentation with js:automodule

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,55 @@ Finally, if you want full control, pull your class members in one at a time by e
        allowing you to intersperse long prose passages and examples that you
        don't want in your code.
 
+automodule
+----------
+
+To document all of your code that belongs to a single module at once, use the ``js:automodule`` directive.
+Start by adding your module documentation on top of your file::
+
+    /**
+    * Module comment goes here.
+    *
+    * @module MyModule
+    */
+
+Provide some extra information with the JSDoc tags ``@author``, ``@version`` or ``@license``::
+
+    /**
+    * Module comment goes here.
+    *
+    * @module   YourModule
+    * @author   your name
+    * @version  0.1.0
+    * @license  MIT
+    */
+
+Use the ``@author`` tag multiple times, if you need::
+
+    /**
+    * Module comment goes here.
+    *
+    * @module   MyModule
+    * @author   company name
+    * @author   name
+    */
+
+Document all of your classes, function or whatever as shown above and use the ``js:automodule`` directive to generate the api. Invoke it with the ``:members:`` option, which automatically includes all members that belongs to the specified module ::
+
+    .. js:automodule:: MyModule
+        :members:
+
+This will even include all class members (if they exist) as well! Include private members by saying ::
+
+    .. js:automodule:: MyModule
+        :private-members:
+
+You can easily control what needs to be included or excluded in the module with the ``:members:`` and ``:exclude-members:`` option ... ::
+
+    .. js:automodule:: MyModule
+        :members: MyClass, memberOfMyClass
+        :exclude-members: Foo, bar, baz, AnotherClass, memberOfAnotherClass
+
 autoattribute
 -------------
 

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -5,7 +5,7 @@ from sphinx.errors import SphinxError
 from .directives import (auto_class_directive_bound_to_app,
                          auto_function_directive_bound_to_app,
                          auto_attribute_directive_bound_to_app,
-                         auto_module_directive_bound_to_app)
+                         auto_module_directive_bound_to_app,
                          JSStaticFunction)
 from .jsdoc import Analyzer as JsAnalyzer
 from .typedoc import Analyzer as TsAnalyzer

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -4,7 +4,8 @@ from sphinx.errors import SphinxError
 
 from .directives import (auto_class_directive_bound_to_app,
                          auto_function_directive_bound_to_app,
-                         auto_attribute_directive_bound_to_app)
+                         auto_attribute_directive_bound_to_app,
+                         auto_module_directive_bound_to_app)
 from .jsdoc import Analyzer as JsAnalyzer
 from .typedoc import Analyzer as TsAnalyzer
 
@@ -26,7 +27,9 @@ def setup(app):
     app.add_directive_to_domain('js',
                                 'autoattribute',
                                 auto_attribute_directive_bound_to_app(app))
-    # TODO: We could add a js:module with app.add_directive_to_domain().
+    app.add_directive_to_domain('js',
+                                'automodule',
+                                auto_module_directive_bound_to_app(app))
 
     app.add_config_value('js_language', 'javascript', 'env')
     app.add_config_value('js_source_path', '../', 'env')

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -10,7 +10,10 @@ can access each other and collaborate.
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import flag
 
-from .renderers import AutoFunctionRenderer, AutoClassRenderer, AutoAttributeRenderer
+from .renderers import (AutoAttributeRenderer,
+                        AutoClassRenderer,
+                        AutoFunctionRenderer,
+                        AutoModuleRenderer)
 
 
 class JsDirective(Directive):
@@ -73,6 +76,25 @@ def auto_attribute_directive_bound_to_app(app):
             return AutoAttributeRenderer.from_directive(self, app).rst_nodes()
 
     return AutoAttributeDirective
+
+
+def auto_module_directive_bound_to_app(app):
+    class AutoModuleDirective(JsDirective):
+        """js:automodule directive, which spits out a js:module directive
+
+        Takes a single argument which is a JS module name.
+
+        """
+        option_spec = JsDirective.option_spec.copy()
+        option_spec.update({
+            'members': lambda members: ([m.strip() for m in members.split(',')]
+                                        if members else None),
+            'exclude-members': _members_to_exclude,
+            'private-members': flag})
+        def run(self):
+            return AutoModuleRenderer.from_directive(self, app).rst_nodes()
+
+    return AutoModuleDirective
 
 
 def _members_to_exclude(arg):

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -91,6 +91,7 @@ def auto_module_directive_bound_to_app(app):
                                         if members else None),
             'exclude-members': _members_to_exclude,
             'private-members': flag})
+
         def run(self):
             return AutoModuleRenderer.from_directive(self, app).rst_nodes()
 

--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -236,5 +236,4 @@ class Module(TopLevel):
     authors: List[str]
     version: str
     license_information: str
-    # functions: Optional[List[Function]]
     members: Optional[List[Union[Class, Function]]]

--- a/sphinx_js/ir.py
+++ b/sphinx_js/ir.py
@@ -229,3 +229,12 @@ class Class(TopLevel, _MembersAndSupers):
     # itself. These are supported and extracted by jsdoc, but they end up in an
     # `undocumented: True` doclet and so are presently filtered out. But we do
     # have the space to include them someday.
+
+
+@dataclass
+class Module(TopLevel):
+    authors: List[str]
+    version: str
+    license_information: str
+    # functions: Optional[List[Function]]
+    members: Optional[List[Union[Class, Function]]]

--- a/sphinx_js/jsdoc.py
+++ b/sphinx_js/jsdoc.py
@@ -64,8 +64,8 @@ class Analyzer:
         self._doclets_by_module = defaultdict(lambda: [])
         for d in doclets:
             of = d.get('memberof')
-            if of:
-                if 'module' in of:
+            if of:  # speed optimization
+                if 'module' in of and '~' not in of:
                     segments = full_path_segments(d, base_dir, longname_field='memberof')
                     self._doclets_by_module[tuple(segments)].append(d)
                 else:

--- a/sphinx_js/jsdoc.py
+++ b/sphinx_js/jsdoc.py
@@ -65,12 +65,12 @@ class Analyzer:
         for d in doclets:
             of = d.get('memberof')
             if of:
-                segments = full_path_segments(d, base_dir, longname_field='memberof')
-                self._doclets_by_class[tuple(segments)].append(d)
-                self._doclets_by_module[tuple(segments)].append(d)
-            else:
-                segments = full_path_segments(d, base_dir, longname_field='longname')
-                self._doclets_by_module[tuple(segments)].append(d)
+                if 'module' in of:
+                    segments = full_path_segments(d, base_dir, longname_field='memberof')
+                    self._doclets_by_module[tuple(segments)].append(d)
+                else:
+                    segments = full_path_segments(d, base_dir, longname_field='memberof')
+                    self._doclets_by_class[tuple(segments)].append(d)
 
     @classmethod
     def from_disk(cls, abs_source_paths, app, base_dir):

--- a/sphinx_js/jsdoc.py
+++ b/sphinx_js/jsdoc.py
@@ -116,10 +116,10 @@ class Analyzer:
             # Typedefs should still fit into function-shaped holes:
             if (kind == 'class'):
                 doclet_as_whatever = self._doclet_as_class
-            elif (kind == 'function'):
+            elif (kind == 'function' or kind == 'typedef'):
                 doclet_as_whatever = self._doclet_as_function
             else:
-                continue    # ignore everything else at module level
+                doclet_as_whatever = self._doclet_as_attribute
             member = doclet_as_whatever(member_doclet, member_full_path)
             members.append(member)
         return Module(

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -45,7 +45,6 @@ class JsRenderer(object):
             prefix = 'module'
             self._partial_path[0] = '{}:{}'.format(prefix, self._partial_path[0])
 
-
     @classmethod
     def from_directive(cls, directive, app):
         """Return one of these whose state is all derived from a directive.
@@ -301,8 +300,7 @@ class AutoModuleRenderer(JsRenderer):
             members=self._members_of(obj,
                                      include=self._options['members'],
                                      exclude=self._options.get('exclude-members', set()))
-                        if 'members' in self._options else '',
-        )
+                    if 'members' in self._options else '')
 
     def _members_of(self, obj, include, exclude):
         """Return RST describing the members of a given module.

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -313,8 +313,10 @@ class AutoModuleRenderer(JsRenderer):
         def rst_for(obj):
             if isinstance(obj, Class):
                 renderer = AutoClassRenderer
-            else:
+            elif isinstance(obj, Function):
                 renderer = AutoFunctionRenderer
+            else:
+                renderer = AutoAttributeRenderer
             return renderer(self._directive,
                             self._app,
                             arguments=['dummy'],

--- a/sphinx_js/templates/module.rst
+++ b/sphinx_js/templates/module.rst
@@ -1,0 +1,27 @@
+{% import 'common.rst' as common %}
+
+.. js:module:: {{ name }}
+
+{{ common.deprecated(deprecated) }}
+
+{% if description -%}
+    {{ description }}
+{%- endif %}
+
+{% if authors -%}
+    **Author(s):** {% for a in authors -%}
+                       {% if loop.last -%}{{ a }}{% else %}{{ a }}, {% endif %}
+                   {%- endfor %}
+{%- endif %}
+
+{% if version -%}
+    **Version:** {{ version }}
+{%- endif %}
+
+{% if license_information -%}
+    **License:** {{ license_information }}
+{%- endif %}
+
+{% if members -%}
+    {{ members }}
+{%- endif %}

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -7,11 +7,11 @@
  *    that wraps
  * @returns {Number} What a thing
  */
-function linkDensity( node ) {
-    const length             = node.flavors.get( 'paragraphish' ).inlineLength;
-    const lengthWithoutLinks = inlineTextLength( node.element,
-        element => element.tagName !== 'A' );
-    return ( length - lengthWithoutLinks ) / length;
+function linkDensity(node) {
+    const length = node.flavors.get('paragraphish').inlineLength;
+    const lengthWithoutLinks = inlineTextLength(node.element,
+                                                element => element.tagName !== 'A');
+    return (length - lengthWithoutLinks) / length;
 }
 
 /**
@@ -23,7 +23,7 @@ class ContainingClass {
      *
      * @arg ho A thing
      */
-    constructor( ho ) {
+    constructor(ho) {
         /**
          * A var
          */
@@ -34,18 +34,17 @@ class ContainingClass {
      * Here.
      * @protected
      */
-    someMethod( hi ) {
+    someMethod(hi) {
     }
 
     /**
      * Setting this also frobs the frobnicator.
      */
     get bar() {
-        return this._bar;
+      return this._bar;
     }
-
-    set bar( baz ) {
-        this._bar = _bar;
+    set bar(baz) {
+      this._bar = _bar;
     }
 
     /**
@@ -149,7 +148,7 @@ const ExampleAttribute = null;
  * @param {string} p2.foo
  * @param {string} p2.bar
  */
-function destructuredParams( p1, { foo, bar } ) {}
+function destructuredParams(p1, {foo, bar}) {}
 
 /**
  * @param a_ Snorf
@@ -166,7 +165,7 @@ function injection() {}
  * @param [num=5]
  * @param [nil=null]
  */
-function defaultsDocumentedInDoclet( func, str, strNum, strBool, num, nil ) {}
+function defaultsDocumentedInDoclet(func, str, strNum, strBool, num, nil) {}
 
 /**
  * @param [num]
@@ -174,14 +173,14 @@ function defaultsDocumentedInDoclet( func, str, strNum, strBool, num, nil ) {}
  * @param [bool]
  * @param [nil]
  */
-function defaultsDocumentedInCode( num = 5, str = "true", bool = true, nil = null ) {}
+function defaultsDocumentedInCode(num=5, str="true", bool=true, nil=null) {}
 
 /**
  * Variadic parameter
  * @param a
  * @param args
  */
-function variadicParameter( a, ...args ) {}
+function variadicParameter(a, ...args) {}
 
 /** @deprecated */
 function deprecatedFunction() {}
@@ -220,7 +219,7 @@ class SeeClass {}
 /**
  * @arg fnodeA {Node|Fnode}
  */
-function union( fnodeA ) {
+function union(fnodeA) {
 }
 
 /**
@@ -233,5 +232,5 @@ function union( fnodeA ) {
  *     illustrious words as aardvark and artichoke.
  * @param b Next param, which should be part of the same field list
  */
-function longDescriptions( a, b ) {
+function longDescriptions(a, b) {
 }

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -7,11 +7,11 @@
  *    that wraps
  * @returns {Number} What a thing
  */
-function linkDensity(node) {
-    const length = node.flavors.get('paragraphish').inlineLength;
-    const lengthWithoutLinks = inlineTextLength(node.element,
-                                                element => element.tagName !== 'A');
-    return (length - lengthWithoutLinks) / length;
+function linkDensity( node ) {
+    const length             = node.flavors.get( 'paragraphish' ).inlineLength;
+    const lengthWithoutLinks = inlineTextLength( node.element,
+        element => element.tagName !== 'A' );
+    return ( length - lengthWithoutLinks ) / length;
 }
 
 /**
@@ -23,7 +23,7 @@ class ContainingClass {
      *
      * @arg ho A thing
      */
-    constructor(ho) {
+    constructor( ho ) {
         /**
          * A var
          */
@@ -34,17 +34,18 @@ class ContainingClass {
      * Here.
      * @protected
      */
-    someMethod(hi) {
+    someMethod( hi ) {
     }
 
     /**
      * Setting this also frobs the frobnicator.
      */
     get bar() {
-      return this._bar;
+        return this._bar;
     }
-    set bar(baz) {
-      this._bar = _bar;
+
+    set bar( baz ) {
+        this._bar = _bar;
     }
 
     /**
@@ -148,7 +149,7 @@ const ExampleAttribute = null;
  * @param {string} p2.foo
  * @param {string} p2.bar
  */
-function destructuredParams(p1, {foo, bar}) {}
+function destructuredParams( p1, { foo, bar } ) {}
 
 /**
  * @param a_ Snorf
@@ -165,7 +166,7 @@ function injection() {}
  * @param [num=5]
  * @param [nil=null]
  */
-function defaultsDocumentedInDoclet(func, str, strNum, strBool, num, nil) {}
+function defaultsDocumentedInDoclet( func, str, strNum, strBool, num, nil ) {}
 
 /**
  * @param [num]
@@ -173,14 +174,14 @@ function defaultsDocumentedInDoclet(func, str, strNum, strBool, num, nil) {}
  * @param [bool]
  * @param [nil]
  */
-function defaultsDocumentedInCode(num=5, str="true", bool=true, nil=null) {}
+function defaultsDocumentedInCode( num = 5, str = "true", bool = true, nil = null ) {}
 
 /**
  * Variadic parameter
  * @param a
  * @param args
  */
-function variadicParameter(a, ...args) {}
+function variadicParameter( a, ...args ) {}
 
 /** @deprecated */
 function deprecatedFunction() {}
@@ -219,7 +220,7 @@ class SeeClass {}
 /**
  * @arg fnodeA {Node|Fnode}
  */
-function union(fnodeA) {
+function union( fnodeA ) {
 }
 
 /**
@@ -232,5 +233,5 @@ function union(fnodeA) {
  *     illustrious words as aardvark and artichoke.
  * @param b Next param, which should be part of the same field list
  */
-function longDescriptions(a, b) {
+function longDescriptions( a, b ) {
 }

--- a/tests/test_build_js/source/docs/automodule.rst
+++ b/tests/test_build_js/source/docs/automodule.rst
@@ -1,0 +1,1 @@
+.. js:automodule:: TestModule

--- a/tests/test_build_js/source/docs/automodule_empty.rst
+++ b/tests/test_build_js/source/docs/automodule_empty.rst
@@ -1,0 +1,1 @@
+.. js:automodule:: EmptyModule

--- a/tests/test_build_js/source/docs/automodule_exclude_members.rst
+++ b/tests/test_build_js/source/docs/automodule_exclude_members.rst
@@ -1,3 +1,3 @@
 .. js:automodule:: TestModule
-    :members: StandardClass, aMember, xMember
-    :exclude-members: simpleFunction, zMember
+    :members:
+    :exclude-members: zMember

--- a/tests/test_build_js/source/docs/automodule_exclude_members.rst
+++ b/tests/test_build_js/source/docs/automodule_exclude_members.rst
@@ -1,0 +1,3 @@
+.. js:automodule:: TestModule
+    :members: StandardClass, aMember, xMember
+    :exclude-members: simpleFunction, zMember

--- a/tests/test_build_js/source/docs/automodule_members.rst
+++ b/tests/test_build_js/source/docs/automodule_members.rst
@@ -1,0 +1,2 @@
+.. js:automodule:: TestModule
+    :members:

--- a/tests/test_build_js/source/docs/automodule_members_list.rst
+++ b/tests/test_build_js/source/docs/automodule_members_list.rst
@@ -1,0 +1,2 @@
+.. js:automodule:: TestModule
+    :members: StandardClass, aMember, simpleFunction

--- a/tests/test_build_js/source/docs/automodule_private_members.rst
+++ b/tests/test_build_js/source/docs/automodule_private_members.rst
@@ -1,0 +1,3 @@
+.. js:automodule:: TestModule
+    :members:
+    :private-members:

--- a/tests/test_build_js/source/emptymodule.js
+++ b/tests/test_build_js/source/emptymodule.js
@@ -1,0 +1,5 @@
+/**
+ * Empty module.
+ *
+ * @module EmptyModule
+ */

--- a/tests/test_build_js/source/module.js
+++ b/tests/test_build_js/source/module.js
@@ -8,9 +8,9 @@
  */
 
 /**
- * SimpleClass.
+ * StandardClass.
  */
-class SimpleClass {}
+class StandardClass {}
 
 /**
  * simpleFunction.

--- a/tests/test_build_js/source/module.js
+++ b/tests/test_build_js/source/module.js
@@ -1,0 +1,23 @@
+/**
+ * For test purpose only.
+ *
+ * @author  xsjad0
+ * @module  TestModule
+ * @version 1.0
+ * @license MIT
+ */
+
+/**
+ * SimpleClass.
+ */
+class SimpleClass {}
+
+/**
+ * simpleFunction.
+ */
+function simpleFunction() {}
+
+/**
+ * someAttribute.
+ */
+const someAttribute = null;

--- a/tests/test_build_js/source/module.js
+++ b/tests/test_build_js/source/module.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * For test purpose only.
  *
@@ -8,9 +9,30 @@
  */
 
 /**
- * StandardClass.
+ * StandardClass doc.
  */
-class StandardClass {}
+class StandardClass {
+    /**
+     * Constructor doc.
+     */
+    constructor() {}
+
+    /**
+     * aMember.
+     */
+    aMember() {}
+
+    /**
+     * zMember.
+     */
+    zMember() {}
+
+    /**
+     * xMember. (private)
+     * @private
+     */
+    xMember() {}
+}
 
 /**
  * simpleFunction.

--- a/tests/test_build_js/source/module.js
+++ b/tests/test_build_js/source/module.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * For test purpose only.
  *

--- a/tests/test_build_js/source/module.js
+++ b/tests/test_build_js/source/module.js
@@ -40,6 +40,6 @@ class StandardClass {
 function simpleFunction() {}
 
 /**
- * someAttribute.
+ * globalConstant.
  */
-const someAttribute = null;
+const globalConstant = null;

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -320,10 +320,81 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '**License:** MIT\n'
             '\n'
-            'class TestModule.StandardClass()\n\n'
-            '   StandardClass.\n'
+            'class TestModule.StandardClass()\n'
+            '\n'
+            '   StandardClass doc.\n'
+            '\n'
+            '   Constructor doc.\n'
+            '\n'
+            '   StandardClass.aMember()\n'
+            '\n'
+            '      aMember.\n'
+            '\n'
+            '   StandardClass.zMember()\n'
+            '\n'
+            '      zMember.\n'
             '\n'
             'TestModule.simpleFunction()\n\n'
+            '   simpleFunction.\n')
+
+    def test_automodule_members_list(self):
+        """Make sure automodule shows only the given members."""
+        self._file_contents_eq(
+            'automodule_members_list',
+            'For test purpose only.\n'
+            '\n'
+            '**Author(s):** xsjad0\n'
+            '\n'
+            '**Version:** 1.0\n'
+            '\n'
+            '**License:** MIT\n'
+            '\n'
+            'class TestModule.StandardClass()\n'
+            '\n'
+            '   StandardClass doc.\n'
+            '\n'
+            '   Constructor doc.\n'
+            '\n'
+            '   StandardClass.aMember()\n'
+            '\n'
+            '      aMember.\n'
+            '\n'
+            'TestModule.simpleFunction()\n'
+            '\n'
+            '   simpleFunction.\n')
+
+    def test_automodule_private_members(self):
+        """Make sure automodule shows members and private members."""
+        self._file_contents_eq(
+            'automodule_private_members',
+            'For test purpose only.\n'
+            '\n'
+            '**Author(s):** xsjad0\n'
+            '\n'
+            '**Version:** 1.0\n'
+            '\n'
+            '**License:** MIT\n'
+            '\n'
+            'class TestModule.StandardClass()\n'
+            '\n'
+            '   StandardClass doc.\n'
+            '\n'
+            '   Constructor doc.\n'
+            '\n'
+            '   StandardClass.aMember()\n'
+            '\n'
+            '      aMember.\n'
+            '\n'
+            '   StandardClass.xMember()\n'
+            '\n'
+            '      xMember. (private)\n'
+            '\n'
+            '   StandardClass.zMember()\n'
+            '\n'
+            '      zMember.\n'
+            '\n'
+            'TestModule.simpleFunction()\n'
+            '\n'
             '   simpleFunction.\n')
 
     def test_automodule_empty(self):

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -294,6 +294,45 @@ class Tests(SphinxBuildTestCase):
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n')
 
+    def test_automodule(self):
+        """Make sure automodule shows its module comment, author(s), version and
+        license information.
+        """
+        self._file_contents_eq(
+            'automodule',
+            'For test purpose only.\n'
+            '\n'
+            '**Author(s):** xsjad0\n'
+            '\n'
+            '**Version:** 1.0\n'
+            '\n'
+            '**License:** MIT\n')
+
+    def test_automodule_members(self):
+        """Make sure automodule shows all of its information including members."""
+        self._file_contents_eq(
+            'automodule_members',
+            'For test purpose only.\n'
+            '\n'
+            '**Author(s):** xsjad0\n'
+            '\n'
+            '**Version:** 1.0\n'
+            '\n'
+            '**License:** MIT\n'
+            '\n'
+            'class TestModule.SimpleClass()\n\n'
+            '   SimpleClass.\n'
+            '\n'
+            'TestModule.simpleFunction()\n\n'
+            '   simpleFunction.\n')
+
+    def test_automodule_empty(self):
+        """Make sure automodule works without specifying author, license and
+        version information."""
+        self._file_contents_eq(
+            'automodule_empty',
+            'Empty module.\n')
+
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""
         self._file_contents_eq(

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -320,8 +320,8 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '**License:** MIT\n'
             '\n'
-            'class TestModule.SimpleClass()\n\n'
-            '   SimpleClass.\n'
+            'class TestModule.StandardClass()\n\n'
+            '   StandardClass.\n'
             '\n'
             'TestModule.simpleFunction()\n\n'
             '   simpleFunction.\n')

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -334,6 +334,10 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '      zMember.\n'
             '\n'
+            'TestModule.globalConstant\n'
+            '\n'
+            '   globalConstant.\n'
+            '\n'
             'TestModule.simpleFunction()\n\n'
             '   simpleFunction.\n')
 
@@ -393,6 +397,10 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '      zMember.\n'
             '\n'
+            'TestModule.globalConstant\n'
+            '\n'
+            '   globalConstant.\n'
+            '\n'
             'TestModule.simpleFunction()\n'
             '\n'
             '   simpleFunction.\n')
@@ -418,6 +426,10 @@ class Tests(SphinxBuildTestCase):
             '   StandardClass.aMember()\n'
             '\n'
             '      aMember.\n'
+            '\n'
+            'TestModule.globalConstant\n'
+            '\n'
+            '   globalConstant.\n'
             '\n'
             'TestModule.simpleFunction()\n'
             '\n'

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -397,6 +397,32 @@ class Tests(SphinxBuildTestCase):
             '\n'
             '   simpleFunction.\n')
 
+    def test_automodule_exclude_members(self):
+        """Make sure automodule shows only members that are not excluded."""
+        self._file_contents_eq(
+            'automodule_exclude_members',
+            'For test purpose only.\n'
+            '\n'
+            '**Author(s):** xsjad0\n'
+            '\n'
+            '**Version:** 1.0\n'
+            '\n'
+            '**License:** MIT\n'
+            '\n'
+            'class TestModule.StandardClass()\n'
+            '\n'
+            '   StandardClass doc.\n'
+            '\n'
+            '   Constructor doc.\n'
+            '\n'
+            '   StandardClass.aMember()\n'
+            '\n'
+            '      aMember.\n'
+            '\n'
+            'TestModule.simpleFunction()\n'
+            '\n'
+            '   simpleFunction.\n')
+
     def test_automodule_empty(self):
         """Make sure automodule works without specifying author, license and
         version information."""


### PR DESCRIPTION
**js:automodule - directive**

Hey Erik!
I have another feature that I want to share with you and others.
With this pull request, I'm going to address issue #5 .

JSDoc provides the ``@module`` tag that marks the current file as being its own JS module (see [JSDoc documentation](https://jsdoc.app/tags-module.html#examples)). With the ``@module`` tag, we tell JSDoc that all symbols in the path are assumed to be members of that module. Additionally, you can use the ``@author``, ``@version`` and ``@license`` tags to display some more information in the module comment. Once we've done this, we can use the ``js:automodule`` directive to document the JS module with all its members at once.

Here's an example:

JS module containing some constants, classes and functions
```js
/**
 * For test purpose only.
 *
 * @module  TestModule
 * @author  xsjad0
 * @version 0.1.0
 * @license MIT
 */

/**
 * Class doc.
 */
 class SimpleClass {
    /**
     * Constructor doc.
     */
    constructor() {}

    /**
     * simpleMethod.
     */
    simpleMethod() {}

    /**
     * privateMethod
     * @private
     */
    privateMethod() {}

    /**
     * simpleAttribute.
     */
    simpleAttribute = "attr"
}

/**
 * simpleFunction.
 */
function simpleFunction() {}

/**
 * globalConstant.
 */
const globalConstant = null;
```

Text to trigger the module documentation
```code
TestModule
==========

.. js:automodule:: TestModule
    :members:
```

HTML output

![image](https://user-images.githubusercontent.com/34922647/117676046-78dadd00-b1ad-11eb-90b1-46a01a1086ec.png)

The ``js:automodule`` directive accepts the options ``:members:``, ``:private-members:`` and ``:exclude-members`` to handle what needs to be documented. These options work on module and on class level. That means that you can control class members as well as module members (maybe there's an even better approach?!)

The additional tags ``@author``, ``@version`` and ``@license`` can be omitted.

Notes:
* The syntax of the ``@module`` tag differs from the syntax described in JSDocs documentation
  * ``@module <moduleName>`` instead of ``@module [[<type>] <moduleName>]``
  * I'm not sure why we would need this?!
* order of the symbols
  * classes
    * attributes
    * methods
  * members/constants (attributes)
  * functions

Notable changes:
* add some tests
* extend readme
* collect doclets by module
* register automodule directive
* add renderer AutoModuleRenderer
* add ir dataclass Module
* add template module.rst

We need to document many classes, namespaces, functions, ... This features safes us a lot of time!
I also started to implement an automodules directive, which makes it even possible to document multiple modules at once.
But first, I want to read your opinion about this feature. Hope you gonna enjoy it!