### PR TITLE
Fixed errors on convering typedoc JSON output to IR object

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -194,7 +194,7 @@ class Analyzer:
             # many attr of Functions.
             sigs = node.get('signatures')
             first_sig = sigs[0]  # Should always have at least one
-            first_sig['sources'] = node['sources']
+            first_sig['sources'] = node.get('sources', node['__parent']['sources'])
             return self._convert_node(first_sig)
         elif kind in ['Call signature', 'Constructor signature']:
             # This is the real meat of a function, method, or constructor.
@@ -228,7 +228,7 @@ class Analyzer:
         """
         types = []
         for type in node.get(kind, []):
-            if type['type'] == 'reference':
+            if type['type'] == 'reference' and type.get('id'):
                 pathname = Pathname(make_path_segments(self._index[type['id']],
                                                        self._base_dir))
                 types.append(pathname)


### PR DESCRIPTION
This is bugfix of converting typedoc json output.
I found that `KeyError: 'id'` raising with 'extendedTypes' objects, not having 'id' key. This happens on processing code with extending classes like:
```
import { SomeClass } from 'module';

class MyClass extends SomeClass {
  //...
}
```
Also `KeyError: 'sources'` raising with Constructor kind when class definition doesn't have one. Example:
```
class SomeClass {}
```
In this case we are getting 'sources' value from the parent Class kind object.