### PR TITLE
Fixes for typedoc ~0.22.11 and strange self-referencing variable issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ sphinx_js.egg-info/
 .vscode
 .DS_Store
 venv
+# Pyenv
+.python-version

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -194,7 +194,15 @@ class Analyzer:
             # many attr of Functions.
             sigs = node.get('signatures')
             first_sig = sigs[0]  # Should always have at least one
-            first_sig['sources'] = node['sources']
+            def rec_helper(node):
+                if "sources" in node["__parent"]:
+                    return node["__parent"]["sources"]
+                else:
+                    rec_helper(node["__parent"])
+            if "sources" in node:
+                first_sig['sources'] = node['sources']
+            else:
+                first_sig['sources'] = rec_helper(node)
             return self._convert_node(first_sig)
         elif kind in ['Call signature', 'Constructor signature']:
             # This is the real meat of a function, method, or constructor.

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -340,8 +340,6 @@ def typedoc_output(abs_source_paths, sphinx_conf_dir, config_path):
     with NamedTemporaryFile(mode='w+b') as temp:
         command.add('--json', temp.name, *abs_source_paths)
         try:
-            from pprint import pprint
-            pprint(command.make())
             subprocess.call(command.make())
         except OSError as exc:
             if exc.errno == ENOENT:

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -195,8 +195,8 @@ class Analyzer:
             sigs = node.get('signatures')
             first_sig = sigs[0]  # Should always have at least one
             parent = node
-            while 'sources' not in node and '__parent' in node:
-                parent = node['__parent']
+            while 'sources' not in parent and '__parent' in parent:
+                parent = parent['__parent']
             first_sig['sources'] = parent['sources']
             return self._convert_node(first_sig)
         elif kind in ['Call signature', 'Constructor signature']:

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -194,15 +194,10 @@ class Analyzer:
             # many attr of Functions.
             sigs = node.get('signatures')
             first_sig = sigs[0]  # Should always have at least one
-            def rec_helper(node):
-                if "sources" in node["__parent"]:
-                    return node["__parent"]["sources"]
-                else:
-                    return rec_helper(node["__parent"])
-            if "sources" in node:
-                first_sig['sources'] = node['sources']
-            else:
-                first_sig['sources'] = rec_helper(node)
+            parent = node
+            while 'sources' not in node and '__parent' in node:
+                parent = node['__parent']
+            first_sig['sources'] = parent['sources']
             return self._convert_node(first_sig)
         elif kind in ['Call signature', 'Constructor signature']:
             # This is the real meat of a function, method, or constructor.


### PR DESCRIPTION
This Pull request includes a fix from @semohr to resolve #166 and also resolves an issue that came up in [this merge request](https://gitlab.com/opencraft/dev/providence/-/merge_requests/2) where a node of type 'reference' did not exist in the index, but did have a 'name' key. This seems to be something that's cropped up in the new version of TypeDoc.

I've also added one additional change-- the ability to recognize literals as types for TypeDoc, so that things like null and 'name' or what have you don't show up as '<TODO: Other Type>'