### PR TITLE
Fix support for typedoc 0.19

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -64,7 +64,7 @@ class Analyzer:
             if not node or node['id'] == 0:
                 # We went all the way up but didn't find a containing module.
                 return
-            elif node.get('kindString') == 'External module':
+            elif node.get('kindString') in ('Module', 'External module'):
                 # Found one!
                 yield node
 
@@ -449,11 +449,13 @@ def make_path_segments(node, base_dir, child_was_static=None):
 
     # Handle the cases here that are handled in _convert_node(), plus any that
     # are encountered on other nodes on the way up to the root.
-    if kind in ['Variable', 'Property', 'Accessor', 'Interface', 'Module']:
+    if kind in ['Variable', 'Property', 'Accessor', 'Interface', 'Namespace']:
         # We emit a segment for a Method's child Call Signature but skip the
         # Method itself. They 2 nodes have the same names, but, by taking the
         # child, we fortuitously end up without a trailing delimiter on our
         # last segment.
+        segments = [node['name']]
+    elif kind == "Module" and not "originalName" in node:
         segments = [node['name']]
     elif kind in ['Call signature', 'Constructor signature']:
         # Similar to above, we skip the parent Constructor and glom onto the
@@ -465,7 +467,7 @@ def make_path_segments(node, base_dir, child_was_static=None):
         segments = [node['name']]
         if child_was_static is False:
             delimiter = '#'
-    elif kind == 'External module':
+    elif kind in ('Module', 'External module'):
         # 'name' contains folder names if multiple folders are passed into
         # TypeDoc. It's also got excess quotes. So we ignore it and take
         # 'originalName', which has a nice, absolute path.


### PR DESCRIPTION
Before this PR:
typedoc v0.15 and 0.16 work
>= 0.17 crash (cannot render anything due to `ValueError('Could not find deppath')`)

After this PR:
v0.15 and 0.16 still work
v0.17 and 0.18 mess up the type name for tuple types due to a bug in these versions of typedoc
TypeNameTests::test_basic - AssertionError: assert '<TODO: other type>' == '[string, number]'
v0.19 works
v0.20+: crash (cannot render anything because "sources" key not always present on nodes and there is another deppath problem).

@rth @ryanking13