### PR TITLE
Switch build backend to hatchling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-recursive-include sphinx_js/templates *.rst
-include LICENSE
-include requirements_dev.txt
-include noxfile.py
-include sphinx_js/js/*.mjs
-include sphinx_js/js/*.ts
-include sphinx_js/js/*.json
-
-recursive-include tests *.py *.rst *.ts *.json *.js *.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "sphinx-js"
@@ -44,6 +44,19 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/pyodide/sphinx-js"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/sphinx_js",
+    "/tests",
+    "/LICENSE",
+    "/requirements_dev.txt",
+    "/noxfile.py",
+    "/README.rst",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["sphinx_js"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-from setuptools import find_packages, setup
-
-setup(
-    packages=find_packages(exclude=["ez_setup"]),
-    include_package_data=True,
-)


### PR DESCRIPTION
This leads to the following improvements:
* Drops all the test files from the wheel
* Add `.gitignore`, remove `CODE_OF_CONDUCT` from sdist