### PR TITLE
Fix running tests with node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set up Python
         uses: actions/setup-python@v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set up Python
         uses: actions/setup-python@v7.0.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ def tests(session: Session) -> None:
     (venvroot / "node_modules").mkdir()
     with session.chdir(venvroot):
         session.run(
-            "npm", "i", "--no-save", "jsdoc@4.0.0", "typedoc@0.25", external=True
+            "npm", "i", "--no-save", "jsdoc@4.0.4", "typedoc@0.25", external=True
         )
     session.run(
         "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ def tests(session: Session) -> None:
     (venvroot / "node_modules").mkdir()
     with session.chdir(venvroot):
         session.run(
-            "npm", "i", "--no-save", "jsdoc@4.0.0", "typedoc@0.25", external=True
+            "npm", "i", "--no-save", "jsdoc@4.0.4", "typedoc@0.25", external=True
         )
     session.run(
         "pytest",
@@ -53,7 +53,7 @@ def test_typedoc(session: Session, typedoc: str) -> None:
             "i",
             "--no-save",
             "tsx",
-            "jsdoc@4.0.0",
+            "jsdoc@4.0.4",
             f"typedoc@{typedoc}",
             external=True,
         )
@@ -86,6 +86,6 @@ def test_sphinx_6(session: Session) -> None:
     (venvroot / "node_modules").mkdir()
     with session.chdir(venvroot):
         session.run(
-            "npm", "i", "--no-save", "jsdoc@4.0.0", "typedoc@0.25", external=True
+            "npm", "i", "--no-save", "jsdoc@4.0.4", "typedoc@0.25", external=True
         )
     session.run("pytest", "--junitxml=test-results.xml", "-k", "not js")


### PR DESCRIPTION
This picks up the latest version of jsdoc which fixes the compatibility issue.

Without this, there are many errors along the lines of:

```
/Users/mark/dev/sphinx-js/.nox/tests-3-13/node_modules/jsdoc/lib/jsdoc/util/dumper.js:98
        else if ( util.isRegExp(o) ) {
                       ^

TypeError: util.isRegExp is not a function
```