### PR TITLE
Unpin markupsafe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "attrs",
     "cattrs<25.1",
     "Jinja2>2.0",
-    "markupsafe==3.0.2",
+    "markupsafe",
     "parsimonious>=0.10.0,<0.11.0",
     "Sphinx>=4.1.0",
 ]


### PR DESCRIPTION
Currently, markupsafe is pinned to version 3.0.2.

This PR removes the `markupsave` version constraint.