### PR TITLE
Include node on typedoc command

### DIFF
--- a/sphinx_js/analyzer_utils.py
+++ b/sphinx_js/analyzer_utils.py
@@ -14,6 +14,14 @@ from sphinx.errors import SphinxError
 def program_name_on_this_platform(program: str) -> str:
     """Return the name of the executable file on the current platform, given a
     command name with no extension."""
+
+    if os.access(program, os.X_OK):
+        return program
+
+    path = shutil.which(program)
+    if path and os.access(path, os.X_OK):
+        return path
+
     return program + ".cmd" if os.name == "nt" else program
 
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -27,8 +27,11 @@ MIN_TYPEDOC_VERSION = (0, 25, 0)
 
 @cache
 def typedoc_version_info(typedoc: str) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    command = Command("node")
+    command.add(typedoc)
+    command.add("--version")
     result = subprocess.run(
-        [typedoc, "--version"],
+        command.make(),
         capture_output=True,
         encoding="utf8",
         check=True,

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -96,8 +96,11 @@ def typedoc_output(
     with NamedTemporaryFile(mode="w+b", delete=False) as temp:
         source_paths = abs_source_paths
         if os.name == "nt":
-            source_paths = map(lambda path: str(posixpath.join(*str(path).split(os.sep))), abs_source_paths)
-    
+            source_paths = map(
+                lambda path: str(posixpath.join(*str(path).split(os.sep))),
+                abs_source_paths,
+            )
+
         command.add("--json", temp.name, *source_paths)
         try:
             subprocess.run(command.make(), check=True, env=env)

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -29,8 +29,7 @@ MIN_TYPEDOC_VERSION = (0, 25, 0)
 @cache
 def typedoc_version_info(typedoc: str) -> tuple[tuple[int, ...], tuple[int, ...]]:
     command = Command("node")
-    command.add(typedoc)
-    command.add("--version")
+    command.add(typedoc, "--version")
     result = subprocess.run(
         command.make(),
         capture_output=True,


### PR DESCRIPTION
Closes #285

I considered updating `search_node_modules` to return a command that may or may not include `"node"` but since including it fixes the Windows issue without breaking other platforms I went with this smaller change instead. This is also consistent with the `jsdoc`invocation where `"node"` is always part of the command.

On my windows machine the version call succeeds now but the project I'm testing it on is throwing an unrelated error about ESM URL schemes. Because of that I still haven't gotten a successful run after my changes, working on it now.

nox is also causing errors when I run it locally so after I get a successful run I'll try and check the tests locally with WSL.