### PR TITLE
Fix compatibility with sphinx 9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: "3.12"
+  python: "3.10"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -12,6 +12,7 @@ from docutils.statemachine import StringList
 from docutils.utils import new_document
 from jinja2 import Environment, PackageLoader
 from sphinx import addnodes
+from sphinx import version_info as sphinx_version_info
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.errors import SphinxError
@@ -778,8 +779,16 @@ class AutoSummaryRenderer(Renderer):
         # extract_summary seems to have trouble if there are Sphinx
         # directives in descr
         descr, _, _ = descr.partition("\n..")
+        document = self._directive.state.document
+        # In Sphinx 9.x, extract_summary takes document.settings directly
+        # instead of the document object.
+        doc_or_settings: Any
+        if sphinx_version_info >= (9, 0):
+            doc_or_settings = document.settings
+        else:
+            doc_or_settings = document
         return extract_summary(
-            [descr.replace(":", colon_esc)], self._directive.state.document
+            [descr.replace(":", colon_esc)], doc_or_settings
         ).replace(colon_esc, ":")
 
     def get_sig(self, obj: TopLevel) -> str:

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 from sphinx.environment import CONFIG_NEW, CONFIG_OK
-from sphinx.testing.util import strip_escseq
+
+try:
+    from sphinx.util.console import strip_colors
+except ImportError:
+    from sphinx.testing.util import strip_escseq as strip_colors
 
 
 def build(app):
@@ -36,7 +40,7 @@ def build(app):
         app.disconnect(doctree_resolved_id)
 
     return (
-        strip_escseq(app._status.getvalue()),
+        strip_colors(app._status.getvalue()),
         list(sorted(reads)),
         list(sorted(writes)),
     )


### PR DESCRIPTION
* `strip_escseq` was changed to `strip_color`
* `extract_summary()` now expects a `settings` instead of a `document`. 
* Set pre-commit python version to 3.10 to avoid pulling in deps that use typing features from newer Python versions.
